### PR TITLE
allas_lib Darwin (OSX) compability check 

### DIFF
--- a/allas-lib
+++ b/allas-lib
@@ -1,7 +1,20 @@
 
 # make secure temp dir and set the global tmp_dir to it
 function make_temp_dir {
+# test if os is Darwin derivative
+
+VAR1=$(uname)
+VAR2='Darwin'
+if  [[ "$VAR1" == "$VAR2" ]]; then
+	if ! [ -x "$(command -v gmktemp)" ]; then
+  	echo 'Error: gmktemp is not installed. This can be found from Coreutils in https://brew.sh/ ' >&2
+  	exit 1
+		else
+  	tmp_dir=$(gmktemp -d -p ${tmp_root} allas-cli-tools-XXXXXX)
+		fi
+else
 	tmp_dir=$(mktemp -d -p ${tmp_root} allas-cli-tools-XXXXXX)
+fi
 }
 
 # remove tmp_dir if it exists


### PR DESCRIPTION
make_temp_dir  fails without gnu mktemp