### PR TITLE
Update allas-dependencies.yaml

### DIFF
--- a/a-get
+++ b/a-get
@@ -651,7 +651,7 @@ else
 	       locked_path=$(dirname "$object_name")
 	       echo "Copying encrypted data"
                #echo "DEBUG 2: rclone copyto -P $rclone_copy_options ${storage_server}:$object_name ./${locked_file}"
-	       rclone $clone_copy_options copyto "${storage_server}:$object_name" "./${locked_file}"
+	       rclone $rclone_copy_options copyto "${storage_server}:$object_name" "./${locked_file}"
 	       echo "Decrypting $locked-file"
 	       echo " sd-lock-util unlock --container "${locked_path}" --no-content-download --no-preserve-original --path "${locked_file}" "
 	       sd-lock-util unlock --container "${locked_path}" --no-content-download --no-preserve-original --path "${locked_file}"

--- a/allas-dependencies.yaml
+++ b/allas-dependencies.yaml
@@ -14,3 +14,4 @@ dependencies:
     - python-swiftclient
     - python-rclone
     - crypt4gh
+    - debtcollector<3.1.0


### PR DESCRIPTION
allas-cli-utils and sd-lock-util cannot be installed together due to debtcollector's dependency conflict. Addresses the issue described here: https://github.com/CSCfi/sd-lock-util/issues/4 and fixes dependency conflict